### PR TITLE
Implement support for GM.xmlHttpRequest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "browser": true,
-    "es2017": true
+    "es2017": true,
+    "greasemonkey": true
   },
   "extends": [
     "standard"

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Some things to be aware off:
   using Greasemonkey, Violentmonkey and Tampermonkey. It might or might not work on other browsers or
   with other user script managers. The code assumes your browser supports modern JS features (at
   least ES2017).
-- The user script does not work with Safari due to strict blocking of unencrypted connections even if
-  they are local.
+- For Safari you need the [Userscripts](https://github.com/quoid/userscripts) extension version 4
+  (which requires macOS 12.0+) and version 0.7 of MusicBrainz Magic Tagger Button.
+  *The user script does not work in Safari with older versions of the Userscripts extension due
+  to strict blocking of unencrypted connections even if they are local.*
 - I still consider this experimental and a proof of concept. It works for me, but might not for you.
 - It is recommended that you have configured Picard to use the default port 8000, but it has to be
   one port between 8000 - 8010.
@@ -56,6 +58,6 @@ Some things to be aware off:
 
 ## License
 
-MusicBrainz Magic Tagger Button © 2021 Philipp Wolfer <ph.wolfer@gmail.com>
+MusicBrainz Magic Tagger Button © 2021-2022 Philipp Wolfer <ph.wolfer@gmail.com>
 
 Published under the MIT license, see [LICENSE](./LICENSE) for details.

--- a/mb-magic-tagger-button.user.js
+++ b/mb-magic-tagger-button.user.js
@@ -21,9 +21,7 @@
 // @exclude       /^https://([.*].)?musicbrainz.org/collection/.*/.*/
 // @exclude       /^https://([.*].)?musicbrainz.org/release-group/.*/.*/
 // @exclude       /^https://([.*].)?musicbrainz.org/series/.*/.*/
-// @grant         none
 // @grant         GM.xmlHttpRequest
-// @grant         GM_xmlhttpRequest
 // @inject-into   content
 // @noframes
 // @homepageURL   https://github.com/phw/musicbrainz-magic-tagger-button
@@ -91,9 +89,6 @@ let xmlHttpRequest
 if (typeof (GM) !== 'undefined' && GM.xmlHttpRequest) {
   debug('Using GM.xmlHttpRequest')
   xmlHttpRequest = GM.xmlHttpRequest
-} else if (typeof (GM_xmlhttpRequest) !== 'undefined') {
-  debug('Using GM_xmlhttpRequest')
-  xmlHttpRequest = GM_xmlhttpRequest
 } else {
   debug('Using XMLHttpRequest')
   xmlHttpRequest = function xmlHttpRequest (details) {

--- a/mb-magic-tagger-button.user.js
+++ b/mb-magic-tagger-button.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          MusicBrainz Magic Tagger Button
 // @description   Automatically enable the green tagger button on MusicBrainz.org depending on whether Picard is running.
-// @version       0.6.3
+// @version       0.7
 // @author        Philipp Wolfer
 // @namespace     https://uploadedlobster.com
 // @license       MIT
@@ -22,6 +22,8 @@
 // @exclude       /^https://([.*].)?musicbrainz.org/release-group/.*/.*/
 // @exclude       /^https://([.*].)?musicbrainz.org/series/.*/.*/
 // @grant         none
+// @grant         GM.xmlHttpRequest
+// @grant         GM_xmlhttpRequest
 // @inject-into   content
 // @noframes
 // @homepageURL   https://github.com/phw/musicbrainz-magic-tagger-button
@@ -85,28 +87,48 @@ const log = (...args) => logger('log', ...args)
 const warn = (...args) => logger('warn', ...args)
 const error = (...args) => logger('error', ...args)
 
+let xmlHttpRequest
+if (typeof (GM) !== 'undefined' && GM.xmlHttpRequest) {
+  debug('Using GM.xmlHttpRequest')
+  xmlHttpRequest = GM.xmlHttpRequest
+} else if (typeof (GM_xmlhttpRequest) !== 'undefined') {
+  debug('Using GM_xmlhttpRequest')
+  xmlHttpRequest = GM_xmlhttpRequest
+} else {
+  debug('Using XMLHttpRequest')
+  xmlHttpRequest = function xmlHttpRequest (details) {
+    const xhr = new XMLHttpRequest()
+    xhr.timeout = details.timeout || 0
+    xhr.open(details.method, details.url)
+    xhr.onload = details.onload.bind(null, xhr)
+    xhr.onerror = details.onerror.bind(null, xhr)
+    xhr.send()
+  }
+}
+
 function makeRequest (method, url) {
   return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest()
-    xhr.timeout = 200
-    xhr.open(method, url)
-    xhr.onload = () => {
+    const successHandler = (response) => {
       resolve({
         method: method,
         url: url,
-        status: xhr.status,
-        statusText: xhr.statusText,
-        response: xhr.response,
-        responseText: xhr.responseText,
+        status: response.status,
+        statusText: response.statusText,
+        responseText: response.responseText,
       })
     }
-    const errorHandler = () => {
-      const msg = `Request failed ${method} ${url}: ${xhr.status} ${xhr.statusText}`
+    const errorHandler = (response) => {
+      const msg = `Request failed ${method} ${url}: ${response.status} ${response.statusText}`
       reject(new Error(msg))
     }
-    xhr.onerror = errorHandler
-    xhr.ontimeout = errorHandler
-    xhr.send()
+    xmlHttpRequest({
+      method: method,
+      url: url,
+      timeout: 200,
+      onload: successHandler,
+      onerror: errorHandler,
+      ontimeout: errorHandler,
+    })
   })
 }
 


### PR DESCRIPTION
This uses the GM API for the network requests, with a fallback to use `XMLHttpRequest` if `GM.xmlHttpRequest` is not available.

This change makes this script work on Safari when using the current Userscripts beta 4, see https://github.com/quoid/userscripts/issues/164