### PR TITLE
Update to target TAGGER_HOST for API calls.

### DIFF
--- a/mb-magic-tagger-button.user.js
+++ b/mb-magic-tagger-button.user.js
@@ -179,7 +179,8 @@ function improveTaggerButtons () {
     button.parentNode.replaceChild(newButton, button)
     newButton.addEventListener('click', async (event) => {
       event.preventDefault()
-      const url = newButton.href
+      const url = new URL(newButton.href)
+      url.host = TAGGER_HOST
       debug('Tagger button clicked', url)
       try {
         const response = await makeRequest('GET', url)


### PR DESCRIPTION
Updated to honor TAGGER_HOST for API calls.  Previously, it was using `127.0.0.1`, regardless of TAGGER_HOST configuration changes.